### PR TITLE
Fix for seek error in overwriting an exsiting file

### DIFF
--- a/FileHandleReader.go
+++ b/FileHandleReader.go
@@ -94,8 +94,9 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 		} else {
 			this.Seeks++
 			err := this.HdfsReader.Seek(fileOffset)
-			if err != nil {
-				log.Printf("[%d] Seek error to %d: %s", this.Offset, fileOffset, err.Error())
+			// If seek error happens, return err. Seek to the end of the file is not an error.
+			if err != nil && this.Offset > fileOffset{
+				log.Printf("[seek offset: %d] Seek error to %d (file offset): %s", this.Offset, fileOffset, err.Error())
 				return 0, err
 			}
 			this.Offset = fileOffset

--- a/FileHandleWriter.go
+++ b/FileHandleWriter.go
@@ -51,6 +51,7 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 		attrs, err := hdfsAccessor.Stat(path)
 		if err != nil {
 			log.Printf("[%s] Can't stat file: %s", path, err)
+			return this, nil
 		}
 		if attrs.Size >= MaxFileSizeForWrite {
 			this.stagingFile.Close()


### PR DESCRIPTION
While overwriting the exsiting file, hdfs-mount tries to read the exsiting file first. This ocassionly causes I/O warning that seek-offset == file-offset, and OS takes the I/O warning as error.
The fix is not to report error when seek-offset == file-offset.