### PR TITLE
Leveled log information

### DIFF
--- a/Dir.go
+++ b/Dir.go
@@ -132,7 +132,7 @@ func (this *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 	allAttrs, err := this.FileSystem.HdfsAccessor.ReadDir(absolutePath)
 	if err != nil {
-		Error.Println("ls: ", err)
+		Warning.Println("ls [", absolutePath, "]: ", err)
 		return nil, err
 	}
 	entries := make([]fuse.Dirent, 0, len(allAttrs))
@@ -179,7 +179,8 @@ func (this *Dir) LookupAttrs(name string, attrs *Attrs) error {
 	var err error
 	*attrs, err = this.FileSystem.HdfsAccessor.Stat(path.Join(this.AbsolutePath(), name))
 	if err != nil {
-		Error.Print("stat: ", err.Error(), err)
+		// It is a warning as each time new file write tries to stat if the file exists
+		Warning.Print("stat [", name, "]: ", err.Error(), err)
 		if pathError, ok := err.(*os.PathError); ok && (pathError.Err == os.ErrNotExist) {
 			return fuse.ENOENT
 		}
@@ -261,7 +262,7 @@ func (this *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fu
 		})()
 
 		if err != nil {
-			Error.Println("Chmod failed with error: ", err)
+			Error.Println("Chmod [", path, "] failed with error: ", err)
 		} else {
 			this.Attrs.Mode = req.Mode
 		}

--- a/Dir_test.go
+++ b/Dir_test.go
@@ -6,6 +6,7 @@ import (
 	"bazil.org/fuse"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
 	"os"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 func TestAttributeCaching(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockClock := &MockClock{}
+	InitLogger(os.Stdout, os.Stdout, os.Stdout, os.Stderr)
 	hdfsAccessor := NewMockHdfsAccessor(mockCtrl)
 	fs, _ := NewFileSystem(hdfsAccessor, "/tmp/x", []string{"*"}, false, NewDefaultRetryPolicy(mockClock), mockClock)
 	root, _ := fs.Root()

--- a/FileHandle.go
+++ b/FileHandle.go
@@ -6,7 +6,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
-	"log"
 	"sync"
 )
 
@@ -67,7 +66,7 @@ func (this *FileHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *f
 	defer this.Mutex.Unlock()
 
 	if this.Reader == nil {
-		log.Printf("[%s] Warning: reading file opened for write @%d", this.File.AbsolutePath(), req.Offset)
+		Warning.Println("[", this.File.AbsolutePath(), "] reading file opened for write @", req.Offset)
 		err := this.EnableRead()
 		if err != nil {
 			return err
@@ -114,12 +113,12 @@ func (this *FileHandle) Fsync(ctx context.Context, req *fuse.FsyncRequest) error
 func (this *FileHandle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
 	if this.Reader != nil {
 		err := this.Reader.Close()
-		log.Printf("[%s] Close/Read: err=%v", this.File.AbsolutePath(), err)
+		Info.Println("[", this.File.AbsolutePath(), "] Close/Read: err=", err)
 		this.Reader = nil
 	}
 	if this.Writer != nil {
 		err := this.Writer.Close()
-		log.Printf("[%s] Close/Write: err=%v", this.File.AbsolutePath(), err)
+		Info.Println("[", this.File.AbsolutePath(), "] Close/Write: err=", err)
 		this.Writer = nil
 	}
 	this.File.InvalidateMetadataCache()

--- a/FileHandleReader.go
+++ b/FileHandleReader.go
@@ -95,7 +95,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 			err := this.HdfsReader.Seek(fileOffset)
 			// If seek error happens, return err. Seek to the end of the file is not an error.
 			if err != nil && this.Offset > fileOffset{
-				Error.Println("[seek offset:", this.Offset, "] Seek error to", fileOffset, "(file offset):", err.Error())
+				Error.Println("[seek", handle.File.AbsolutePath(), " @offset:", this.Offset, "] Seek error to", fileOffset, "(file offset):", err.Error())
 				return 0, err
 			}
 			this.Offset = fileOffset
@@ -109,7 +109,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 	err := this.Buffer1.ReadFromBackend(this.HdfsReader, &this.Offset, minBytesToRead, maxBytesToRead)
 	if err != nil {
 		if err == io.EOF {
-			Error.Println("[", handle.File.AbsolutePath(), "] EOF @", this.Offset)
+			Warning.Println("[", handle.File.AbsolutePath(), "] EOF @", this.Offset)
 			return 0, err
 		}
 		return 0, err

--- a/FileHandleReader.go
+++ b/FileHandleReader.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"golang.org/x/net/context"
 	"io"
-	"log"
 )
 
 // Encapsulates state and routines for reading data from the file handle
@@ -31,7 +30,7 @@ func NewFileHandleReader(handle *FileHandle) (*FileHandleReader, error) {
 	var err error
 	this.HdfsReader, err = handle.File.FileSystem.HdfsAccessor.OpenRead(handle.File.AbsolutePath())
 	if err != nil {
-		log.Printf("[%s] ERROR opening: %s", handle.File.AbsolutePath(), err)
+		Error.Println("[", handle.File.AbsolutePath(), "] Opening: ", err)
 		return nil, err
 	}
 	this.Buffer1 = &FileFragment{}
@@ -96,7 +95,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 			err := this.HdfsReader.Seek(fileOffset)
 			// If seek error happens, return err. Seek to the end of the file is not an error.
 			if err != nil && this.Offset > fileOffset{
-				log.Printf("[seek offset: %d] Seek error to %d (file offset): %s", this.Offset, fileOffset, err.Error())
+				Error.Println("[seek offset:", this.Offset, "] Seek error to", fileOffset, "(file offset):", err.Error())
 				return 0, err
 			}
 			this.Offset = fileOffset
@@ -110,7 +109,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 	err := this.Buffer1.ReadFromBackend(this.HdfsReader, &this.Offset, minBytesToRead, maxBytesToRead)
 	if err != nil {
 		if err == io.EOF {
-			log.Printf("[%s] EOF @%d", handle.File.AbsolutePath(), this.Offset)
+			Error.Println("[", handle.File.AbsolutePath(), "] EOF @", this.Offset)
 			return 0, err
 		}
 		return 0, err
@@ -125,7 +124,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 // Closes the reader
 func (this *FileHandleReader) Close() error {
 	if this.HdfsReader != nil {
-		log.Printf("[%s] ReadStats: holes: %d, cache hits: %d, hard seeks: %d", this.Handle.File.AbsolutePath(), this.Holes, this.CacheHits, this.Seeks)
+		Info.Println("[", this.Handle.File.AbsolutePath(), "] ReadStats: holes:", this.Holes, ", cache hits:", this.CacheHits, ", hard seeks:", this.Seeks)
 		this.HdfsReader.Close()
 		this.HdfsReader = nil
 	}

--- a/FileHandleWriter.go
+++ b/FileHandleWriter.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 )
 
@@ -24,7 +23,7 @@ type FileHandleWriter struct {
 // Opens the file for writing
 func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, error) {
 	this := &FileHandleWriter{Handle: handle}
-	log.Printf("newFile=%v", newFile)
+	Info.Println("newFile=", newFile)
 	path := this.Handle.File.AbsolutePath()
 
 	hdfsAccessor := this.Handle.File.FileSystem.HdfsAccessor
@@ -32,7 +31,7 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 		hdfsAccessor.Remove(path)
 		w, err := hdfsAccessor.CreateFile(path, this.Handle.File.Attrs.Mode)
 		if err != nil {
-			log.Printf("ERROR creating %s: %s", path, err)
+			Error.Println("Creating", path, ":", path, err)
 			return nil, err
 		}
 		w.Close()
@@ -50,32 +49,32 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 		// Request to write to existing file
 		attrs, err := hdfsAccessor.Stat(path)
 		if err != nil {
-			log.Printf("[%s] Can't stat file: %s", path, err)
+			Error.Println("[", path, "] Can't stat file:", err)
 			return this, nil
 		}
 		if attrs.Size >= MaxFileSizeForWrite {
 			this.stagingFile.Close()
 			this.stagingFile = nil
-			log.Printf("[%s] Maximum allowed file size for writing exceeded (%d >= %d)", path, attrs.Size, MaxFileSizeForWrite)
+			Error.Println("[", path, "] Maximum allowed file size for writing exceeded (", attrs.Size, " >=", MaxFileSizeForWrite, ")")
 			return nil, errors.New("Too large file")
 		}
 
-		log.Printf("Buffering contents of the file to the staging area %s...", this.stagingFile.Name())
+		Info.Println("Buffering contents of the file to the staging area ", this.stagingFile.Name())
 		reader, err := hdfsAccessor.OpenRead(path)
 		if err != nil {
-			log.Printf("HDFS/open failure: %s", err)
+			Error.Println("HDFS/open failure:", err)
 			this.stagingFile.Close()
 			this.stagingFile = nil
 			return nil, err
 		}
 		nc, err := io.Copy(this.stagingFile, reader)
 		if err != nil {
-			log.Printf("Copy failure: %s", err)
+			Error.Println("Copy failure:", err)
 			this.stagingFile.Close()
 			this.stagingFile = nil
 			return nil, err
 		}
-		log.Printf("Copied %d bytes", nc)
+		Info.Println("Copied", nc, "bytes")
 	}
 
 	return this, nil
@@ -84,7 +83,7 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 // Responds on FUSE Write request
 func (this *FileHandleWriter) Write(handle *FileHandle, ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
 	if uint64(req.Offset) >= MaxFileSizeForWrite {
-		log.Printf("[%s] Maximum allowed file size for writing exceeded (%d >= %d)", this.Handle.File.AbsolutePath(), req.Offset, MaxFileSizeForWrite)
+		Error.Println("[", this.Handle.File.AbsolutePath(), "] Maximum allowed file size for writing exceeded (", req.Offset, ">= ", MaxFileSizeForWrite, ")")
 		return errors.New("Too large file")
 	}
 	nw, err := this.stagingFile.WriteAt(req.Data, req.Offset)
@@ -98,7 +97,7 @@ func (this *FileHandleWriter) Write(handle *FileHandle, ctx context.Context, req
 
 // Responds on FUSE Flush/Fsync request
 func (this *FileHandleWriter) Flush() error {
-	log.Printf("[%s] flush (%d new bytes written)", this.Handle.File.AbsolutePath(), this.BytesWritten)
+	Info.Println("[", this.Handle.File.AbsolutePath(), "] flush (", this.BytesWritten, "new bytes written)")
 	if this.BytesWritten == 0 {
 		// Nothing to do
 		return nil
@@ -109,7 +108,7 @@ func (this *FileHandleWriter) Flush() error {
 	op := this.Handle.File.FileSystem.RetryPolicy.StartOperation()
 	for {
 		err := this.FlushAttempt()
-		if IsSuccessOrBenignError(err) || !op.ShouldRetry("[%s] Flush()", err) {
+		if IsSuccessOrBenignError(err) || !op.ShouldRetry("Flush()", err) {
 			return err
 		}
 	}
@@ -122,7 +121,7 @@ func (this *FileHandleWriter) FlushAttempt() error {
 	hdfsAccessor.Remove(this.Handle.File.AbsolutePath())
 	w, err := hdfsAccessor.CreateFile(this.Handle.File.AbsolutePath(), this.Handle.File.Attrs.Mode)
 	if err != nil {
-		log.Printf("ERROR creating %s: %s", this.Handle.File.AbsolutePath(), err)
+		Error.Println("ERROR creating", this.Handle.File.AbsolutePath(), ":", err)
 		return err
 	}
 
@@ -137,7 +136,7 @@ func (this *FileHandleWriter) FlushAttempt() error {
 
 		_, err = w.Write(b)
 		if err != nil {
-			log.Printf("ERROR closing %s: %s", this.Handle.File.AbsolutePath(), err)
+			Error.Println("Closing", this.Handle.File.AbsolutePath(), ":", err)
 			w.Close()
 			return err
 		}
@@ -145,7 +144,7 @@ func (this *FileHandleWriter) FlushAttempt() error {
 	}
 	err = w.Close()
 	if err != nil {
-		log.Printf("ERROR closing %s: %s", this.Handle.File.AbsolutePath(), err)
+		Error.Println("Closing", this.Handle.File.AbsolutePath(), ":", err)
 		return err
 	}
 

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/colinmarc/hdfs"
 	"github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
 	"io"
-	"log"
 	"os"
 	"os/user"
 	"strconv"
@@ -89,7 +88,7 @@ func (this *hdfsAccessorImpl) ConnectToNameNode() (*hdfs.Client, error) {
 		this.CurrentNameNodeIdx = (this.CurrentNameNodeIdx + 1) % len(this.NameNodeAddresses)
 		return nil, errors.New(fmt.Sprintf("%s: %s", nnAddr, err.Error()))
 	}
-	log.Printf("Connected to name node %s", nnAddr)
+	Info.Println("Connected to name node:", nnAddr)
 	return client, nil
 }
 

--- a/Log.go
+++ b/Log.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"io"
+)
+
+var Info    *log.Logger
+var Warning *log.Logger
+var Error   *log.Logger
+var Fatal   *log.Logger
+
+func InitLogger(info, warning, err, fatal io.Writer) {
+	Info = log.New(info, "INFO: ", log.Ldate | log.Ltime)
+	Warning = log.New(warning, "Warning: ", log.Lshortfile | log.Ldate | log.Ltime)
+	Error = log.New(err, "Error: ", log.Lshortfile | log.Ldate | log.Ltime)
+	Fatal = log.New(fatal, "Fatal error: ", log.Llongfile | log.Ldate | log.Ltime)
+}

--- a/RetryPolicy.go
+++ b/RetryPolicy.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"time"
 )
@@ -68,7 +67,7 @@ func (op *Op) ShouldRetry(message string, args ...interface{}) bool {
 		diag = "exceeded max configured time interval for retries"
 	}
 	if diag != "" {
-		log.Printf(fmt.Sprintf("%s -> failed attempt #%d: will NOT be retried (%s)", message, op.Attempt, diag), args...)
+		Error.Printf(fmt.Sprintf("%s -> failed attempt #%d: will NOT be retried (%s)", message, op.Attempt, diag), args...)
 		return false
 	}
 	// Computing delay (exponential backoff)
@@ -87,7 +86,7 @@ func (op *Op) ShouldRetry(message string, args ...interface{}) bool {
 	}
 
 	// Logging information about failed attempt
-	log.Printf(fmt.Sprintf("%s -> failed attempt #%d: retrying in %s", message, op.Attempt, effectiveDelay), args...)
+	Warning.Printf(fmt.Sprintf("%s -> failed attempt #%d: retrying in %s", message, op.Attempt, effectiveDelay), args...)
 	op.Attempt++
 
 	// Sleeping

--- a/ZipDir.go
+++ b/ZipDir.go
@@ -7,7 +7,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
-	"log"
 	"strings"
 	"sync"
 )
@@ -62,14 +61,14 @@ func (this *ZipDir) ReadArchive() error {
 	var attr fuse.Attr
 	err := this.ZipContainerFile.Attr(nil, &attr)
 	if err != nil {
-		log.Printf("Error opening zip file: %s: %s", this.ZipContainerFile.AbsolutePath(), err.Error())
+		Error.Println("Error opening zip file: ", this.ZipContainerFile.AbsolutePath(), " : ", err.Error())
 		return err
 	}
 	zipArchiveReader, err := zip.NewReader(randomAccessReader, int64(attr.Size))
 	if err == nil {
-		log.Printf("Opened zip file: %s", this.ZipContainerFile.AbsolutePath())
+		Info.Println("Opened zip file: ", this.ZipContainerFile.AbsolutePath())
 	} else {
-		log.Printf("Error opening zip file: %s: %s", this.ZipContainerFile.AbsolutePath(), err.Error())
+		Error.Println("Opening zip file: ", this.ZipContainerFile.AbsolutePath(), " : ", err.Error())
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	_ "bazil.org/fuse/fs/fstestutil"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -34,6 +35,7 @@ func main() {
 	allowedPrefixesString := flag.String("allowedPrefixes", "*", "Comma-separated list of allowed path prefixes on the remote file system, "+
 		"if specified the mount point will expose access to those prefixes only")
 	expandZips := flag.Bool("expandZips", false, "Enables automatic expansion of ZIP archives")
+	logLevel := flag.Int("logLevel", 0, "logs to be printed. 0: only fatal/err logs; 1: +warning logs; 2: +info logs")
 
 	flag.Usage = Usage
 	flag.Parse()
@@ -46,6 +48,14 @@ func main() {
 	allowedPrefixes := strings.Split(*allowedPrefixesString, ",")
 
 	retryPolicy.MaxAttempts += 1 // converting # of retry attempts to total # of attempts
+
+	if *logLevel == 0 {
+		InitLogger(ioutil.Discard, ioutil.Discard, os.Stdout, os.Stderr)
+	} else if *logLevel == 1 {
+		InitLogger(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr)
+	} else {
+		InitLogger(os.Stdout, os.Stdout, os.Stdout, os.Stderr)
+	}
 
 	hdfsAccessor, err := NewHdfsAccessor(flag.Arg(0), WallClock{})
 	if err != nil {


### PR DESCRIPTION
New option "-logLevel=<int>" for hdfs-mount for different log levels.
    -logLevel=0, default, print out error logs only
    -logLevel=1, print out error and warning logs
    -logLevel=2, print out all logs
