### PR TITLE
Increase the maximum file handler from 1K to 1M

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,15 @@ func main() {
 	}
 	log.Print("Mounted successfully")
 
+	// Increase the maximum number of file descriptor from 1K to 1M in Linux
+	rLimit := syscall.Rlimit {
+		Cur: 1024*1024,
+		Max: 1024*1024}
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		Error.Printf("Failed to update the maximum number of file descriptors from 1K to 1M, %v", err)
+	}
+
 	defer func() {
 		fileSystem.Unmount()
 		log.Print("Closing...")


### PR DESCRIPTION
The default file handler limitation on Linux for each process is 1K, which could be too few. Increase this number to 1M for hdfs-mount process only.
This option requires sudo privilege, or no change happens with an error msg.