### PR TITLE
Remove the MaxFileSizeForWrite limitation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ go:
   - 1.7
   - 1.6
   - 1.5
+sudo: true
+before_install:
+  - sudo mkdir -m 777 -p /var/hdfs-mount
 install: make
 script:
   - make test
-sudo: false
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Attrs.go
+++ b/Attrs.go
@@ -22,6 +22,13 @@ type Attrs struct {
 	Expires time.Time // indicates when cached attribute information expires
 }
 
+// FsInfo provides information about HDFS
+type FsInfo struct {
+	capacity              uint64
+	used                  uint64
+	remaining             uint64
+}
+
 // Converts Attrs datastructure into FUSE represnetation
 func (this *Attrs) Attr(a *fuse.Attr) error {
 	a.Inode = this.Inode

--- a/FaultTolerantHdfsAccessor.go
+++ b/FaultTolerantHdfsAccessor.go
@@ -75,6 +75,17 @@ func (this *FaultTolerantHdfsAccessor) Stat(path string) (Attrs, error) {
 	}
 }
 
+// Retrieves HDFS usage
+func (this *FaultTolerantHdfsAccessor) StatFs() (FsInfo, error) {
+	op := this.RetryPolicy.StartOperation()
+	for {
+		result, err := this.Impl.StatFs()
+		if IsSuccessOrBenignError(err) || !op.ShouldRetry("StatFs: %s", err) {
+			return result, err
+		}
+	}
+}
+
 // Creates a directory
 func (this *FaultTolerantHdfsAccessor) Mkdir(path string, mode os.FileMode) error {
 	op := this.RetryPolicy.StartOperation()

--- a/FileHandleWriter.go
+++ b/FileHandleWriter.go
@@ -35,7 +35,10 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 		w.Close()
 	}
 	stageDir := "/var/hdfs-mount" // TODO: make configurable
-	os.MkdirAll(stageDir, 0700)
+	if ok := os.MkdirAll(stageDir, 0700); ok != nil {
+		Error.Println("Failed to create stageDir /var/hdfs-mount, Error:", ok)
+		return nil, ok
+	}
 	var err error
 	this.stagingFile, err = ioutil.TempFile(stageDir, "stage")
 	if err != nil {

--- a/FileHandleWriter_test.go
+++ b/FileHandleWriter_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bazil.org/fuse"
+	"errors"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestWriteFile(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockClock := &MockClock{}
+	hdfsAccessor := NewMockHdfsAccessor(mockCtrl)
+	fileName := "/testWriteFile_1"
+	fs, _ := NewFileSystem(hdfsAccessor, "/tmp/x", []string{"*"}, false, NewDefaultRetryPolicy(mockClock), mockClock)
+
+	hdfswriter := NewMockHdfsWriter(mockCtrl)
+	hdfsAccessor.EXPECT().Remove(fileName).Return(nil)
+	hdfsAccessor.EXPECT().CreateFile(fileName, os.FileMode(0757)).Return(hdfswriter, nil)
+	hdfswriter.EXPECT().Close().Return(nil)
+
+	hdfsAccessor.EXPECT().Remove(fileName).Return(nil)
+	root, _ := fs.Root()
+	_, h, _ := root.(*Dir).Create(nil, &fuse.CreateRequest{Name: fileName, Mode: os.FileMode(0757)}, &fuse.CreateResponse{})
+
+	// Test for newfilehandlewriter
+	hdfsAccessor.EXPECT().CreateFile(fileName, os.FileMode(0757)).Return(hdfswriter, nil)
+	hdfswriter.EXPECT().Close().Return(nil)
+	writeHandle, err := NewFileHandleWriter(h.(*FileHandle), true)
+	assert.Nil(t, err)
+
+	// Test for normal write
+	hdfsAccessor.EXPECT().StatFs().Return(FsInfo{capacity: uint64(100), used: uint64(20), remaining: uint64(80)}, nil)
+	err = writeHandle.Write(h.(*FileHandle), nil, &fuse.WriteRequest{Data: []byte("hello world"), Offset: int64(11)}, &fuse.WriteResponse{})
+	assert.Nil(t, err)
+	assert.Equal(t, writeHandle.BytesWritten, uint64(11))
+
+	// Test for writing file larger than available size
+	hdfsAccessor.EXPECT().StatFs().Return(FsInfo{capacity: uint64(100), used: uint64(95), remaining: uint64(5)}, nil)
+	err = writeHandle.Write(h.(*FileHandle), nil, &fuse.WriteRequest{Data: []byte("hello world"), Offset: int64(11)}, &fuse.WriteResponse{})
+	assert.Equal(t, err, errors.New("Too large file"))
+}


### PR DESCRIPTION
Query the HDFS remaining size to write. New support for `df` command in hdfs-mount. Note, FUSE collects File system's total capacity and available capacity only, which may result in mismatch on the used capacity between `df` result and `hdfs fs -df` result.