### PR TITLE
No errors for the Parallel write

### DIFF
--- a/File.go
+++ b/File.go
@@ -50,10 +50,20 @@ func (this *File) Attr(ctx context.Context, a *fuse.Attr) error {
 func (this *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
 	Info.Println("Open: ", this.AbsolutePath(), req.Flags)
 	handle := NewFileHandle(this)
-	if req.Flags.IsReadOnly() || req.Flags.IsReadWrite() {
+	if req.Flags.IsReadOnly() {
 		err := handle.EnableRead()
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if req.Flags.IsReadWrite() {
+		// Open file in readwrite mode. It is ok if file does not exist
+		err := handle.EnableRead()
+		if err != nil {
+			if err = handle.EnableWrite(req.Flags&fuse.OpenAppend != fuse.OpenAppend); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/File_test.go
+++ b/File_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+package main
+
+import (
+	"bazil.org/fuse"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"os"
+	"testing"
+)
+
+func TestFileSetattr(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockClock := &MockClock{}
+	hdfsAccessor := NewMockHdfsAccessor(mockCtrl)
+	fs, _ := NewFileSystem(hdfsAccessor, "/tmp/x", []string{"foo", "bar"}, false, NewDefaultRetryPolicy(mockClock), mockClock)
+	root, _ := fs.Root()
+
+	hdfswriter := NewMockHdfsWriter(mockCtrl)
+	hdfsAccessor.EXPECT().Remove("/testFileSetattr").Return(nil)
+
+	hdfsAccessor.EXPECT().CreateFile("/testFileSetattr", os.FileMode(0757)).Return(hdfswriter, nil)
+	file := root.(*Dir).NodeFromAttrs(Attrs{Name: "/testFileSetattr", Mode: os.FileMode(0757), Uid: uint32(500), Gid: uint32(500)})
+
+	hdfsAccessor.EXPECT().Chmod("/testFileSetattr", os.FileMode(0777)).Return(nil)
+	err := file.(*File).Setattr(nil, &fuse.SetattrRequest{Mode: os.FileMode(0777), Valid: fuse.SetattrMode}, &fuse.SetattrResponse{})
+	assert.Nil(t, err)
+	assert.Equal(t, os.FileMode(0777), file.(*File).Attrs.Mode)
+}


### PR DESCRIPTION
If more than one thread write to the same file in append mode, the file would be open in readwrite mode. But the file does not exist yet on HDFS (no flushing until closing), the file cannot be open in read mode. Change the file open as in write if file is not there yet when open file in readwrite.

This may result in corrupt file, as there are more than 1 thread writes to the same offset of the file. Linux FS uses a lock for writing the file, but HDFS does not support concurrent write to same file.