### PR TITLE
Avoid removing files .Trash on HDFS, which can be used for recovery 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _*
 mock_*
 hdfs-mount
+coverage.txt

--- a/Dir.go
+++ b/Dir.go
@@ -219,6 +219,11 @@ func (this *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse
 // Responds on FUSE Remove request
 func (this *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 	path := this.AbsolutePathForChild(req.Name)
+	// Donot remove the .Trash directory in HDFS
+	if strings.Contains(path, ".Trash") {
+		Error.Println("Trying to remove .Trash directory on HDFS, path is", path)
+		return nil
+	}
 	Info.Println("Remove", path)
 	err := this.FileSystem.HdfsAccessor.Remove(path)
 	if err == nil {

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -315,7 +315,8 @@ func (this *hdfsAccessorImpl) Remove(path string) error {
 		return nil
 	}
 	// Simulate the operation "hdfs dfs -rm <path>"
-	trashPath := "/user/root/.Trash/" + path
+	trashPath := "/user/root/.Trash/" + time.Now().UTC().Format("20060102150405") + "/" + path
+	Info.Println(path, "Deleted (Removed to ", trashPath, ")")
 	return this.Rename(path, trashPath)
 }
 

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -314,14 +314,9 @@ func (this *hdfsAccessorImpl) Remove(path string) error {
 		Error.Println("Trying to remove files in .Trash on HDFS, path is", path)
 		return nil
 	}
-	this.MetadataClientMutex.Lock()
-	defer this.MetadataClientMutex.Unlock()
-	if this.MetadataClient == nil {
-		if err := this.ConnectMetadataClient(); err != nil {
-			return err
-		}
-	}
-	return this.MetadataClient.Remove(path)
+	// Simulate the operation "hdfs dfs -rm <path>"
+	trashPath := "/user/root/.Trash/" + path
+	return this.Rename(path, trashPath)
 }
 
 // Renames file or directory

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -309,6 +309,11 @@ func (this *hdfsAccessorImpl) Mkdir(path string, mode os.FileMode) error {
 
 // Removes file or directory
 func (this *hdfsAccessorImpl) Remove(path string) error {
+	// Donot remove the files in .Trash directory in HDFS
+	if strings.Contains(path, ".Trash") {
+		Error.Println("Trying to remove files in .Trash on HDFS, path is", path)
+		return nil
+	}
 	this.MetadataClientMutex.Lock()
 	defer this.MetadataClientMutex.Unlock()
 	if this.MetadataClient == nil {

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ test: hdfs-mount \
 	mock_HdfsAccessor_test.go \
 	mock_ReadSeekCloser_test.go \
 	mock_HdfsWriter_test.go
-	go test -covermode atomic
+	go test -coverprofile coverage.txt -covermode atomic


### PR DESCRIPTION
If files are in .Trash directory, skip the deletion but return success still.