### PR TITLE
Closing unused connections.

### DIFF
--- a/FaultTolerantHdfsReader.go
+++ b/FaultTolerantHdfsReader.go
@@ -35,6 +35,8 @@ func (this *FaultTolerantHdfsReader) Read(buffer []byte) (int, error) {
 			// Seeking to the right offset
 			if err = this.Impl.Seek(this.Offset); err != nil {
 				// Those errors are non-recoverable propagating right away
+				this.Impl.Close()
+				this.Impl = nil
 				return 0, err
 			}
 		}

--- a/FileHandleWriter.go
+++ b/FileHandleWriter.go
@@ -69,6 +69,7 @@ func NewFileHandleWriter(handle *FileHandle, newFile bool) (*FileHandleWriter, e
 			this.stagingFile = nil
 			return nil, err
 		}
+		reader.Close()
 		Info.Println("Copied", nc, "bytes")
 	}
 

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -111,7 +111,7 @@ func (this *hdfsAccessorImpl) connectToNameNodeImpl(nnAddr string) (*hdfs.Client
 		// Succesfully connected
 		return client, nil
 	} else {
-		//TODO: how to close connection ?
+		client.Close()
 		return nil, statErr
 	}
 }
@@ -124,7 +124,7 @@ func (this *hdfsAccessorImpl) OpenRead(path string) (ReadSeekCloser, error) {
 	}
 	reader, err2 := client.Open(path)
 	if err2 != nil {
-		//TODO: close connection
+		client.Close()
 		return nil, err2
 	}
 	return NewHdfsReader(reader), nil


### PR DESCRIPTION
The connections being closed fall into the categories:
a. Connection was created, but some other condition failed.
b. A temporary connection was created, but not closed.