### PR TITLE
Treat "permission denied" as a benign error.

### DIFF
--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -285,7 +285,7 @@ func IsSuccessOrBenignError(err error) bool {
 	if err == nil || err == io.EOF || err == fuse.EEXIST {
 		return true
 	}
-	if pathError, ok := err.(*os.PathError); ok && (pathError.Err == os.ErrNotExist) {
+	if pathError, ok := err.(*os.PathError); ok && (pathError.Err == os.ErrNotExist || pathError.Err == os.ErrPermission) {
 		return true
 	} else {
 		return false


### PR DESCRIPTION
os.ErrPermission was not treated a non-retryable error. This led to
directory listing not working if the mounting user did not have access
to one of the filesystems subdirectories when listing, as a global lock
would be held by the unsuccessful retry.

By passing through permission denied correctly, this behavior is resolved.