### PR TITLE
Pass the ownership of zipfile to the files in zipfile

### DIFF
--- a/ZipDir.go
+++ b/ZipDir.go
@@ -84,6 +84,8 @@ func (this *ZipDir) ReadArchive() error {
 		attrs := Attrs{
 			Mode:   zipFile.Mode(),
 			Mtime:  zipFile.ModTime(),
+			Uid:    this.Attrs.Uid,
+			Gid:    this.Attrs.Gid,
 			Ctime:  zipFile.ModTime(),
 			Crtime: zipFile.ModTime(),
 			Size:   zipFile.UncompressedSize64,

--- a/Zip_test.go
+++ b/Zip_test.go
@@ -46,7 +46,7 @@ func TestZipDirReadArchive(t *testing.T) {
 	assert.Nil(t, err)
 	zipFileInfo, err := zipFile.Stat()
 	assert.Nil(t, err)
-	hdfsAccessor.EXPECT().Stat("/test.zip").Return(Attrs{Name: "test.zip", Size: uint64(zipFileInfo.Size())}, nil)
+	hdfsAccessor.EXPECT().Stat("/test.zip").Return(Attrs{Name: "test.zip", Size: uint64(zipFileInfo.Size()), Uid: uint32(500), Gid: uint32(500)}, nil)
 	hdfsAccessor.EXPECT().OpenRead("/test.zip").Return(ReadSeekCloser(&FileAsReadSeekCloser{File: zipFile}), err)
 	root, err := fs.Root()
 	zipRootDirNode, err := root.(*Dir).Lookup(nil, "test.zip@")
@@ -61,6 +61,7 @@ func TestZipDirReadArchive(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "a", a.(*ZipFile).Attrs.Name)
 	assert.Equal(t, uint64(1234), a.(*ZipFile).Attrs.Size)
+	assert.Equal(t, uint32(500), a.(*ZipFile).Attrs.Uid)
 
 	baz, err := foo.(*ZipDir).Lookup(nil, "baz")
 	assert.Nil(t, err)

--- a/Zip_test.go
+++ b/Zip_test.go
@@ -66,10 +66,12 @@ func TestZipDirReadArchive(t *testing.T) {
 	baz, err := foo.(*ZipDir).Lookup(nil, "baz")
 	assert.Nil(t, err)
 	assert.Equal(t, "baz", baz.(*ZipDir).Attrs.Name)
+	assert.Equal(t, uint32(500), baz.(*ZipDir).Attrs.Uid)
 
 	x, err := baz.(*ZipDir).Lookup(nil, "x")
 	assert.Nil(t, err)
 	assert.Equal(t, "x", x.(*ZipDir).Attrs.Name)
+	assert.Equal(t, uint32(500), x.(*ZipDir).Attrs.Uid)
 
 	y, err := x.(*ZipDir).Lookup(nil, "y")
 	assert.Nil(t, err)
@@ -83,6 +85,7 @@ func TestZipDirReadArchive(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "w", w.(*ZipFile).Attrs.Name)
 	assert.Equal(t, uint64(256), w.(*ZipFile).Attrs.Size)
+	assert.Equal(t, uint32(500), w.(*ZipFile).Attrs.Uid)
 
 	b, err := foo.(*ZipDir).Lookup(nil, "b")
 	assert.Nil(t, err)


### PR DESCRIPTION
The files show in zipfile as root:root. Because no ownership attr passed in.