### PR TITLE
Run gofmt and add linting to CI

### DIFF
--- a/Attrs.go
+++ b/Attrs.go
@@ -24,9 +24,9 @@ type Attrs struct {
 
 // FsInfo provides information about HDFS
 type FsInfo struct {
-	capacity              uint64
-	used                  uint64
-	remaining             uint64
+	capacity  uint64
+	used      uint64
+	remaining uint64
 }
 
 // Converts Attrs datastructure into FUSE represnetation

--- a/FaultTolerantHdfsAccessor_test.go
+++ b/FaultTolerantHdfsAccessor_test.go
@@ -42,7 +42,7 @@ func TestMkdirWithRetries(t *testing.T) {
 	ftHdfsAccessor := NewFaultTolerantHdfsAccessor(hdfsAccessor, atMost2Attempts())
 	hdfsAccessor.EXPECT().Mkdir("/test/dir", os.FileMode(0757)).Return(errors.New("Injected failure"))
 	hdfsAccessor.EXPECT().Mkdir("/test/dir", os.FileMode(0757)).Return(nil)
-        hdfsAccessor.EXPECT().Close().Return(nil)
+	hdfsAccessor.EXPECT().Close().Return(nil)
 	err := ftHdfsAccessor.Mkdir("/test/dir", os.FileMode(0757))
 	assert.Nil(t, err)
 }
@@ -56,7 +56,7 @@ func TestReadDirWithRetries(t *testing.T) {
 	var err error
 	hdfsAccessor.EXPECT().ReadDir("/test/dir").Return(nil, errors.New("Injected failure"))
 	hdfsAccessor.EXPECT().ReadDir("/test/dir").Return(make([]Attrs, 10), nil)
-        hdfsAccessor.EXPECT().Close().Return(nil)
+	hdfsAccessor.EXPECT().Close().Return(nil)
 	result, err = ftHdfsAccessor.ReadDir("/test/dir")
 	assert.Nil(t, err)
 	assert.Equal(t, 10, len(result))
@@ -72,7 +72,7 @@ func TestOpenReadWithRetries(t *testing.T) {
 	var err error
 	hdfsAccessor.EXPECT().OpenRead("/test/file").Return(nil, errors.New("Injected failure"))
 	hdfsAccessor.EXPECT().OpenRead("/test/file").Return(mockReader, nil)
-        hdfsAccessor.EXPECT().Close().Return(nil)
+	hdfsAccessor.EXPECT().Close().Return(nil)
 	result, err = ftHdfsAccessor.OpenRead("/test/file")
 	assert.Nil(t, err)
 	assert.Equal(t, mockReader, result.(*FaultTolerantHdfsReader).Impl)

--- a/FaultTolerantHdfsReader.go
+++ b/FaultTolerantHdfsReader.go
@@ -80,4 +80,3 @@ func (this *FaultTolerantHdfsReader) Close() error {
 	this.Impl = nil
 	return err
 }
-

--- a/FileHandleReader.go
+++ b/FileHandleReader.go
@@ -94,7 +94,7 @@ func (this *FileHandleReader) ReadPartial(handle *FileHandle, fileOffset int64, 
 			this.Seeks++
 			err := this.HdfsReader.Seek(fileOffset)
 			// If seek error happens, return err. Seek to the end of the file is not an error.
-			if err != nil && this.Offset > fileOffset{
+			if err != nil && this.Offset > fileOffset {
 				Error.Println("[seek", handle.File.AbsolutePath(), " @offset:", this.Offset, "] Seek error to", fileOffset, "(file offset):", err.Error())
 				return 0, err
 			}

--- a/FileSystem.go
+++ b/FileSystem.go
@@ -59,7 +59,7 @@ func (this *FileSystem) Mount() (*fuse.Conn, error) {
 			fuse.VolumeName("HDFS filesystem"),
 			fuse.AllowOther(),
 			fuse.WritebackCache(),
-			fuse.MaxReadahead(1024*64),  //TODO: make configurable
+			fuse.MaxReadahead(1024*64), //TODO: make configurable
 			fuse.ReadOnly())
 	} else {
 		conn, err = fuse.Mount(
@@ -69,7 +69,7 @@ func (this *FileSystem) Mount() (*fuse.Conn, error) {
 			fuse.VolumeName("HDFS filesystem"),
 			fuse.AllowOther(),
 			fuse.WritebackCache(),
-			fuse.MaxReadahead(1024*64))  //TODO: make configurable
+			fuse.MaxReadahead(1024*64)) //TODO: make configurable
 	}
 	if err != nil {
 		return nil, err

--- a/HdfsAccessor.go
+++ b/HdfsAccessor.go
@@ -96,7 +96,7 @@ func (this *hdfsAccessorImpl) connectToNameNodeImpl() (*hdfs.Client, error) {
 	// Colinmar's hdfs implementation has supported the multiple name node connection
 	client, err := hdfs.NewClient(hdfs.ClientOptions{
 		Addresses: this.NameNodeAddresses,
-		})
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func (this *hdfsAccessorImpl) AttrsFromFileInfo(fileInfo os.FileInfo) Attrs {
 }
 
 func (this *hdfsAccessorImpl) AttrsFromFsInfo(fsInfo hdfs.FsInfo) FsInfo {
-	return FsInfo {
+	return FsInfo{
 		capacity:  fsInfo.Capacity,
 		used:      fsInfo.Used,
 		remaining: fsInfo.Remaining}
@@ -358,12 +358,12 @@ func (this *hdfsAccessorImpl) Chown(path string, user, group string) error {
 	return this.MetadataClient.Chown(path, user, group)
 }
 
-// Close current connection if needed 
+// Close current connection if needed
 func (this *hdfsAccessorImpl) Close() error {
 	this.MetadataClientMutex.Lock()
 	defer this.MetadataClientMutex.Unlock()
 
-	if(this.MetadataClient != nil) {
+	if this.MetadataClient != nil {
 		err := this.MetadataClient.Close()
 		this.MetadataClient = nil
 		return err

--- a/Log.go
+++ b/Log.go
@@ -3,18 +3,18 @@
 package main
 
 import (
-	"log"
 	"io"
+	"log"
 )
 
-var Info    *log.Logger
+var Info *log.Logger
 var Warning *log.Logger
-var Error   *log.Logger
-var Fatal   *log.Logger
+var Error *log.Logger
+var Fatal *log.Logger
 
 func InitLogger(info, warning, err, fatal io.Writer) {
-	Info = log.New(info, "INFO: ", log.Ldate | log.Ltime)
-	Warning = log.New(warning, "Warning: ", log.Lshortfile | log.Ldate | log.Ltime)
-	Error = log.New(err, "Error: ", log.Lshortfile | log.Ldate | log.Ltime)
-	Fatal = log.New(fatal, "Fatal error: ", log.Llongfile | log.Ldate | log.Ltime)
+	Info = log.New(info, "INFO: ", log.Ldate|log.Ltime)
+	Warning = log.New(warning, "Warning: ", log.Lshortfile|log.Ldate|log.Ltime)
+	Error = log.New(err, "Error: ", log.Lshortfile|log.Ldate|log.Ltime)
+	Fatal = log.New(fatal, "Fatal error: ", log.Llongfile|log.Ldate|log.Ltime)
 }

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ mock_%_test.go: %.go | $(MOCKGEN_DIR)/mockgen
 	$(MOCKGEN_DIR)/mockgen -source $< -package main > $@~
 	mv -f $@~ $@
 
-test: hdfs-mount \
+test: lint \
+	hdfs-mount \
 	$(GOPATH)/src/github.com/stretchr/testify/assert \
 	$(GOPATH)/src/github.com/golang/mock/gomock \
 	$(MOCKGEN_DIR)/mockgen \
@@ -50,3 +51,7 @@ test: hdfs-mount \
 	mock_ReadSeekCloser_test.go \
 	mock_HdfsWriter_test.go
 	go test -coverprofile coverage.txt -covermode atomic
+
+lint:
+	test -z $$(gofmt -l .) || (echo "gofmt found lint errors"; exit 1)
+

--- a/Zip_test.go
+++ b/Zip_test.go
@@ -73,7 +73,7 @@ func TestZipDirReadArchive(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "x", x.(*ZipDir).Attrs.Name)
 	assert.Equal(t, uint32(500), x.(*ZipDir).Attrs.Uid)
-	assert.Equal(t, os.ModeDir | 0775, x.(*ZipDir).Attrs.Mode)
+	assert.Equal(t, os.ModeDir|0775, x.(*ZipDir).Attrs.Mode)
 
 	y, err := x.(*ZipDir).Lookup(nil, "y")
 	assert.Nil(t, err)


### PR DESCRIPTION
Run gofmt to fix up existing linting errors and add this to the Makefile to prevent further linting errors being merged.